### PR TITLE
extract the stack name from the function name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,6 @@ main: *.go
 release: lambda.zip
 	aws s3 cp lambda.zip s3://convox/lambda/syslog.zip  --acl public-read
 	for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-central-1 \
-		eu-west-1 us-east-1 us-east-2 us-west-1 us-west-2   ; do \
+		eu-west-1 us-east-1 us-east-2 us-west-1 us-west-2; do \
 		aws s3 cp lambda.zip s3://convox-$$region/lambda/syslog.zip --acl public-read; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ main: *.go
 
 release: lambda.zip
 	aws s3 cp lambda.zip s3://convox/lambda/syslog.zip  --acl public-read
-	for region in us-east-1 us-west-2 eu-west-1 ap-northeast-1 ap-southeast-2; do \
+	for region in ap-northeast-1 ap-southeast-1 ap-southeast-2 eu-central-1 \
+		eu-west-1 us-east-1 us-east-2 us-west-1 us-west-2   ; do \
 		aws s3 cp lambda.zip s3://convox-$$region/lambda/syslog.zip --acl public-read; \
 	done

--- a/main.go
+++ b/main.go
@@ -21,7 +21,8 @@ import (
 
 func main() {
 	lambda_proc.Run(func(context *lambda_proc.Context, eventJSON json.RawMessage) (interface{}, error) {
-		syslogUrl, err := readOrDescribeURL(context.FunctionName)
+		stackName := getStackName(context.FunctionName)
+		syslogUrl, err := readOrDescribeURL(stackName)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "readOrDescribeURL err=%s\n", err)
 			return nil, err
@@ -108,6 +109,15 @@ func contentFormatter(p syslog.Priority, hostname, tag, content string) string {
 		22, 1, timestamp.Format(time.RFC3339), hostname, program, tag, content)
 
 	return msg
+}
+
+func getStackName(functionName string) string {
+	i := strings.Index(functionName, "-Function")
+	if i == -1 {
+		return functionName
+	} else {
+		return functionName[:i]
+	}
 }
 
 func readOrDescribeURL(name string) (string, error) {


### PR DESCRIPTION
This change supports https://github.com/convox/rack/pull/1553

We're removing the custom name from the Lambda function. Previously the function was set the same as the stack name. Now we will need to parse out the stack name from the generated function name.