### PR TITLE
Output content mismatch for debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func contentFormatter(p syslog.Priority, hostname, tag, content string) string {
 		}
 		content = m[5]
 	} else {
-		fmt.Fprintf(os.Stderr, "Re.FindStringSubmatch miss\n")
+		fmt.Fprintf(os.Stderr, "Re.FindStringSubmatch miss content=%s\n", content)
 	}
 
 	msg := fmt.Sprintf("<%d>%d %s %s %s %s - - %s\n",


### PR DESCRIPTION
We're seeing `Re.FindStringSubmatch miss` in our logs but it's difficult to line up the error with a corresponding log line. Hoping to get some more useful info for debugging.